### PR TITLE
Add offline Restaurant LeadGen demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+app/node_modules
+app/package-lock.json

--- a/adapters/drive.adapter.js
+++ b/adapters/drive.adapter.js
@@ -1,0 +1,12 @@
+const MODE = import.meta.env.VITE_MODE || 'demo';
+
+export async function uploadToDrive() {
+  if (MODE === 'live') {
+    throw new Error('Live mode not implemented');
+  }
+  return new Promise(resolve => setTimeout(() => resolve({ success: true }), 1000));
+}
+
+export async function uploadToDriveLive(file, credentials) {
+  throw new Error('Live mode not implemented');
+}

--- a/adapters/openai.adapter.js
+++ b/adapters/openai.adapter.js
@@ -1,0 +1,55 @@
+const MODE = import.meta.env.VITE_MODE || 'demo';
+
+const audits = {
+  'https://vodenica-strumica.mk': {
+    issues: ['Missing meta description', 'No sitemap'],
+    fixes: ['Add concise meta description', 'Create XML sitemap']
+  },
+  'https://kajstefan.mk': {
+    issues: ['Slow LCP', 'Missing alt text'],
+    fixes: ['Optimize images for LCP', 'Provide descriptive alt text']
+  },
+  'https://burebarut.mk': {
+    issues: ['No HTTPS', 'Title too short'],
+    fixes: ['Install SSL certificate', 'Expand page title to 60 characters']
+  },
+  'https://urbanbistro.mk': {
+    issues: ['Missing meta description'],
+    fixes: ['Add meta description summarizing the page']
+  },
+  'https://mimoza.mk': {
+    issues: ['No sitemap', 'Images lack alt'],
+    fixes: ['Generate XML sitemap', 'Add alt text to images']
+  },
+  'https://bravoff.mk': {
+    issues: ['Slow LCP', 'No canonical tag'],
+    fixes: ['Compress large assets', 'Add canonical link element']
+  },
+  'https://napoli-pizza.mk': {
+    issues: ['No meta description', 'Missing structured data'],
+    fixes: ['Write meta description', 'Add JSON-LD schema markup']
+  },
+  'https://siriusstrumica.mk': {
+    issues: ['Large images', 'No robots.txt'],
+    fixes: ['Resize images for web', 'Create robots.txt file']
+  },
+  'https://etnoselo.mk': {
+    issues: ['Missing alt text'],
+    fixes: ['Provide alt text for all images']
+  },
+  'https://kafanaskar.mk': {
+    issues: ['No sitemap', 'Slow server response'],
+    fixes: ['Add sitemap.xml', 'Improve server response time']
+  }
+};
+
+export async function auditSeo(url) {
+  if (MODE === 'live') {
+    throw new Error('Live mode not implemented');
+  }
+  return audits[url];
+}
+
+export async function auditSeoLive(url, apiKey) {
+  throw new Error('Live mode not implemented');
+}

--- a/adapters/serpapi.adapter.js
+++ b/adapters/serpapi.adapter.js
@@ -1,0 +1,25 @@
+const MODE = import.meta.env.VITE_MODE || 'demo';
+
+const demoResults = [
+  { name: 'Restaurant Vodenica', address: 'Marshal Tito 20, Strumica', phone: '+38934311222', website: 'https://vodenica-strumica.mk' },
+  { name: 'Kaj Stefan', address: 'Goce Delcev 12, Strumica', phone: '+38934322334', website: 'https://kajstefan.mk' },
+  { name: 'Bure Barut', address: 'Leninova 5, Strumica', phone: '+38934222111', website: 'https://burebarut.mk' },
+  { name: 'Urban Bistro', address: 'Ilinden 34, Strumica', phone: '+38934345566', website: 'https://urbanbistro.mk' },
+  { name: 'Gostilnica Mimoza', address: 'Partizanska 9, Strumica', phone: '+38934234567', website: 'https://mimoza.mk' },
+  { name: 'Fast Food Bravo', address: 'Dimitar Vlahov 3, Strumica', phone: '+38934387654', website: 'https://bravoff.mk' },
+  { name: 'Picerija Napoli', address: 'Samoilova 17, Strumica', phone: '+38934316554', website: 'https://napoli-pizza.mk' },
+  { name: 'Hotel Restoran Sirius', address: 'Blagoj Jankov Muceto bb, Strumica', phone: '+38934312345', website: 'https://siriusstrumica.mk' },
+  { name: 'Etno Selo', address: 'Mladinska 45, Strumica', phone: '+38934398765', website: 'https://etnoselo.mk' },
+  { name: 'Kafana Skar', address: 'Vidoe Smilevski Bato 8, Strumica', phone: '+38934345678', website: 'https://kafanaskar.mk' }
+];
+
+export async function getRestaurants() {
+  if (MODE === 'live') {
+    throw new Error('Live mode not implemented');
+  }
+  return demoResults;
+}
+
+export async function getRestaurantsLive(query, apiKey) {
+  throw new Error('Live mode not implemented');
+}

--- a/adapters/whatsapp.adapter.js
+++ b/adapters/whatsapp.adapter.js
@@ -1,0 +1,13 @@
+const MODE = import.meta.env.VITE_MODE || 'demo';
+
+export async function sendWhatsApp(phone, message) {
+  if (MODE === 'live') {
+    throw new Error('Live mode not implemented');
+  }
+  console.log(`WhatsApp to ${phone}: ${message}`);
+  return { success: true };
+}
+
+export async function sendWhatsAppLive(phone, message, credentials) {
+  throw new Error('Live mode not implemented');
+}

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Restaurant LeadGen Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "restaurant-leadgen-demo",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "xlsx": "^0.18.5"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { getRestaurants } from '~adapters/serpapi.adapter.js';
+import { auditSeo } from '~adapters/openai.adapter.js';
+import { uploadToDrive } from '~adapters/drive.adapter.js';
+import { sendWhatsApp } from '~adapters/whatsapp.adapter.js';
+import { mockSiteHtml } from './mock/siteHtml.js';
+import { saveAsExcel } from './utils/excel.js';
+
+const defaultCity = 'Strumica';
+const defaultCountry = 'North Macedonia';
+
+export default function App() {
+  const [city, setCity] = useState(defaultCity);
+  const [country, setCountry] = useState(defaultCountry);
+  const [leads, setLeads] = useState([]);
+  const [toast, setToast] = useState('');
+  const [uploading, setUploading] = useState(false);
+  const [uploaded, setUploaded] = useState(false);
+
+  const runDemo = async () => {
+    const results = await getRestaurants();
+    const shuffled = [...results].sort(() => Math.random() - 0.5);
+    const enriched = await Promise.all(
+      shuffled.map(async r => {
+        const html = mockSiteHtml[r.website] || '';
+        const mailto = html.match(/mailto:([^"'>]+)/i);
+        const textEmail = html.match(/[\w.-]+@[\w.-]+\.[A-Za-z]{2,}/i);
+        const email = mailto ? mailto[1] : (textEmail ? textEmail[0] : null);
+        const audit = await auditSeo(r.website);
+        return {
+          ...r,
+          email,
+          city,
+          country,
+          seoIssues: audit.issues,
+          proposedFixes: audit.fixes,
+          auditedAt: new Date().toISOString(),
+          approved: false
+        };
+      })
+    );
+    setLeads(enriched);
+    setUploaded(false);
+    setToast('Demo data loaded');
+    setTimeout(() => setToast(''), 2000);
+  };
+
+  const exportExcel = () => {
+    saveAsExcel(leads, city, country);
+  };
+
+  const upload = async () => {
+    setUploading(true);
+    setUploaded(false);
+    await uploadToDrive();
+    setUploading(false);
+    setUploaded(true);
+  };
+
+  const handleSend = async (lead) => {
+    const message = `Hello ${lead.name}, we found SEO issues on ${lead.website}: ${lead.seoIssues.join(', ')}. We can help fix them.`;
+    await sendWhatsApp(lead.phone, message);
+    alert(`WhatsApp to ${lead.phone}:\n${message}`);
+  };
+
+  const toggleApprove = (idx) => {
+    const updated = [...leads];
+    updated[idx].approved = !updated[idx].approved;
+    setLeads(updated);
+  };
+
+  return (
+    <div className="container">
+      <h1>Restaurant LeadGen Demo</h1>
+      <div className="controls">
+        <input value={city} onChange={e => setCity(e.target.value)} />
+        <input value={country} onChange={e => setCountry(e.target.value)} />
+        <button onClick={runDemo}>Run Demo</button>
+        <button onClick={exportExcel} disabled={!leads.length}>Export Excel</button>
+        <button onClick={upload} disabled={!leads.length || uploading}>{uploading ? 'Uploading…' : uploaded ? 'Uploaded ✓' : 'Upload to Drive (Demo)'}</button>
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Business Name</th>
+            <th>Address</th>
+            <th>Phone</th>
+            <th>Email</th>
+            <th>Website</th>
+            <th>SEO Issues</th>
+            <th>Proposed Fixes</th>
+            <th>Approve</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {leads.map((lead, idx) => (
+            <tr key={lead.website}>
+              <td>{lead.name}</td>
+              <td>{lead.address}</td>
+              <td>{lead.phone}</td>
+              <td>{lead.email || '—'}</td>
+              <td><a href={lead.website} target="_blank" rel="noreferrer">{lead.website}</a></td>
+              <td>{lead.seoIssues.join(', ')}</td>
+              <td>{lead.proposedFixes.join(', ')}</td>
+              <td><input type="checkbox" checked={lead.approved} onChange={() => toggleApprove(idx)} /></td>
+              <td>
+                <button onClick={() => handleSend(lead)} disabled={!lead.approved}>Send WhatsApp</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {toast && <div className="toast">{toast}</div>}
+    </div>
+  );
+}

--- a/app/src/main.jsx
+++ b/app/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/app/src/mock/siteHtml.js
+++ b/app/src/mock/siteHtml.js
@@ -1,0 +1,12 @@
+export const mockSiteHtml = {
+  'https://vodenica-strumica.mk': '<html><body><a href="mailto:info@vodenica-strumica.mk">Email us</a></body></html>',
+  'https://kajstefan.mk': '<html><body>Contact: stefan@kajstefan.mk</body></html>',
+  'https://burebarut.mk': '<html><body><p>No email here</p></body></html>',
+  'https://urbanbistro.mk': '<html><body><a href="mailto:hello@urbanbistro.mk">Mail</a></body></html>',
+  'https://mimoza.mk': '<html><body>Reach us at mimoza@gmail.com for info</body></html>',
+  'https://bravoff.mk': '<html><body><a href="mailto:orders@bravoff.mk">orders</a></body></html>',
+  'https://napoli-pizza.mk': '<html><body><p>Best pizza in town</p></body></html>',
+  'https://siriusstrumica.mk': '<html><body><a href="mailto:hotel@siriusstrumica.mk">contact</a></body></html>',
+  'https://etnoselo.mk': '<html><body>Email: info@etnoselo.mk</body></html>',
+  'https://kafanaskar.mk': '<html><body><p>Traditional food</p></body></html>'
+};

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1,0 +1,60 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  margin: 0;
+  padding: 20px;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.controls {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+button {
+  padding: 8px 16px;
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+button:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+th, td {
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+  text-align: left;
+}
+
+th {
+  background: #f0f0f0;
+}
+
+.toast {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  background: #16a34a;
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}

--- a/app/src/utils/excel.js
+++ b/app/src/utils/excel.js
@@ -1,0 +1,21 @@
+import { utils, writeFileXLSX } from 'xlsx';
+
+export function saveAsExcel(leads, city, country) {
+  if (!leads.length) return;
+  const data = leads.map(l => ({
+    'Business Name': l.name,
+    'Address': l.address,
+    'Phone': l.phone,
+    'Email': l.email || '',
+    'Website': l.website,
+    'SEO Issues': l.seoIssues.join('; '),
+    'Proposed Fixes': l.proposedFixes.join('; '),
+    'City': l.city,
+    'Country': l.country
+  }));
+  const ws = utils.json_to_sheet(data);
+  const wb = utils.book_new();
+  utils.book_append_sheet(wb, ws, 'Leads');
+  const today = new Date().toISOString().slice(0,10);
+  writeFileXLSX(wb, `${city}_Restaurants_${today}.xlsx`);
+}

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    fs: {
+      allow: ['..']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      '~adapters': path.resolve(__dirname, '../adapters')
+    }
+  }
+});

--- a/demo/.env.demo.example
+++ b/demo/.env.demo.example
@@ -1,0 +1,5 @@
+SERPAPI_KEY=demo_xxx
+OPENAI_API_KEY=demo_xxx
+DRIVE_KEY=demo_xxx
+WHATSAPP_KEY=demo_xxx
+# Demo mode never uses these keys.

--- a/demo/README_DEMO.md
+++ b/demo/README_DEMO.md
@@ -1,0 +1,25 @@
+# Restaurant LeadGen Demo
+
+This demo runs entirely offline with mock data.
+
+## Run locally
+
+```bash
+cd app
+npm install
+npm run dev
+```
+
+Open `http://localhost:5173` in your browser.
+
+No API keys are required. Demo mode never makes network calls.
+
+## UI actions
+
+- **Run Demo**: loads a shuffled list of Strumica restaurants.
+- **Export Excel**: downloads `Strumica_Restaurants_<date>.xlsx`.
+- **Upload to Drive (Demo)**: shows "Uploading…" then "Uploaded ✓".
+- **Approve**: toggle approval per business to enable WhatsApp send.
+- **Send WhatsApp**: shows the personalized message preview and logs success.
+
+![screenshot placeholder](screenshot.png)

--- a/n8n/outreach_demo.json
+++ b/n8n/outreach_demo.json
@@ -1,0 +1,84 @@
+{
+  "name": "outreach_demo",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "Manual",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {"name": "name", "value": "Restaurant Vodenica"},
+            {"name": "phone", "value": "+38934311222"},
+            {"name": "approved", "value": "true"}
+          ]
+        },
+        "options": {}
+      },
+      "id": "Lead",
+      "name": "Lead",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [200, 0]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{$json[\"approved\"]}}",
+              "operation": "isTrue"
+            }
+          ],
+          "string": [
+            {
+              "value1": "={{$json[\"phone\"]}}",
+              "operation": "isNotEmpty"
+            }
+          ]
+        }
+      },
+      "id": "If",
+      "name": "IF",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [400, 0]
+    },
+    {
+      "parameters": {
+        "values": {"string": [{"name": "status", "value": "sent"}]},
+        "options": {}
+      },
+      "id": "Send",
+      "name": "Send",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [600, -80]
+    },
+    {
+      "parameters": {
+        "fileName": "whatsapp.log",
+        "data": "={{$json.name}} - {{$json.phone}}\n",
+        "append": true
+      },
+      "id": "Log",
+      "name": "Log",
+      "type": "n8n-nodes-base.writeTextFile",
+      "typeVersion": 1,
+      "position": [800, -80]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {"main": [[{"node": "Lead", "type": "main", "index": 0}]]},
+    "Lead": {"main": [[{"node": "IF", "type": "main", "index": 0}]]},
+    "IF": {"main": [[{"node": "Send", "type": "main", "index": 0}], []]},
+    "Send": {"main": [[{"node": "Log", "type": "main", "index": 0}]]}
+  },
+  "active": false,
+  "version": 1
+}

--- a/n8n/scraper_demo.json
+++ b/n8n/scraper_demo.json
@@ -1,0 +1,105 @@
+{
+  "name": "scraper_demo",
+  "nodes": [
+    {
+      "parameters": {
+        "triggerTimes": [{"mode": "everyDay"}]
+      },
+      "id": "Cron",
+      "name": "Cron",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [-200, 0]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "results",
+              "value": "[{\"name\":\"Restaurant Vodenica\",\"website\":\"https://vodenica-strumica.mk\"}]"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "Set1",
+      "name": "Mock SerpApi",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "batchSize": 1
+      },
+      "id": "Split",
+      "name": "Split In Batches",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 1,
+      "position": [200, 0]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {"name": "html", "value": "<html><a href='mailto:info@vodenica-strumica.mk'>Email</a></html>"},
+            {"name": "email", "value": "info@vodenica-strumica.mk"}
+          ]
+        },
+        "options": {}
+      },
+      "id": "Set2",
+      "name": "Mock HTML",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [400, 0]
+    },
+    {
+      "parameters": {
+        "operation": "toFile",
+        "binaryPropertyName": "data"
+      },
+      "id": "Sheet",
+      "name": "Spreadsheet File",
+      "type": "n8n-nodes-base.spreadsheetFile",
+      "typeVersion": 1,
+      "position": [600, 0]
+    },
+    {
+      "parameters": {
+        "fileName": "Strumica.xlsx",
+        "binaryData": true,
+        "dataPropertyName": "data"
+      },
+      "id": "Write",
+      "name": "Write Binary File",
+      "type": "n8n-nodes-base.writeBinaryFile",
+      "typeVersion": 1,
+      "position": [800, 0]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [{"name": "status", "value": "upload success"}]
+        },
+        "options": {}
+      },
+      "id": "Done",
+      "name": "Done",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [1000, 0]
+    }
+  ],
+  "connections": {
+    "Cron": {"main": [[{"node": "Mock SerpApi", "type": "main", "index": 0}]]},
+    "Mock SerpApi": {"main": [[{"node": "Split In Batches", "type": "main", "index": 0}]]},
+    "Split In Batches": {"main": [[{"node": "Mock HTML", "type": "main", "index": 0}]]},
+    "Mock HTML": {"main": [[{"node": "Spreadsheet File", "type": "main", "index": 0}]]},
+    "Spreadsheet File": {"main": [[{"node": "Write Binary File", "type": "main", "index": 0}]]},
+    "Write Binary File": {"main": [[{"node": "Done", "type": "main", "index": 0}]]}
+  },
+  "active": false,
+  "version": 1
+}

--- a/n8n/seo_demo.json
+++ b/n8n/seo_demo.json
@@ -1,0 +1,77 @@
+{
+  "name": "seo_demo",
+  "nodes": [
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {"name": "website", "value": "https://vodenica-strumica.mk"}
+          ]
+        },
+        "options": {}
+      },
+      "id": "Input",
+      "name": "Input",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {"name": "audit", "value": "{\\"issues\\":[\\"Missing meta description\\"],\\"fixes\\":[\\"Add meta description\\"]}"}
+          ]
+        },
+        "options": {}
+      },
+      "id": "Audit",
+      "name": "Mock Audit",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [200, 0]
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combinationMode": "paired"
+      },
+      "id": "Merge",
+      "name": "Merge",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 1,
+      "position": [400, 0]
+    },
+    {
+      "parameters": {
+        "operation": "toFile",
+        "binaryPropertyName": "data"
+      },
+      "id": "Sheet",
+      "name": "Spreadsheet File",
+      "type": "n8n-nodes-base.spreadsheetFile",
+      "typeVersion": 1,
+      "position": [600, 0]
+    },
+    {
+      "parameters": {
+        "fileName": "seo_audit.xlsx",
+        "binaryData": true,
+        "dataPropertyName": "data"
+      },
+      "id": "Write",
+      "name": "Write Binary File",
+      "type": "n8n-nodes-base.writeBinaryFile",
+      "typeVersion": 1,
+      "position": [800, 0]
+    }
+  ],
+  "connections": {
+    "Input": {"main": [[{"node": "Merge", "type": "main", "index": 0}]]},
+    "Mock Audit": {"main": [[{"node": "Merge", "type": "main", "index": 1}]]},
+    "Merge": {"main": [[{"node": "Spreadsheet File", "type": "main", "index": 0}]]},
+    "Spreadsheet File": {"main": [[{"node": "Write Binary File", "type": "main", "index": 0}]]}
+  },
+  "active": false,
+  "version": 1
+}

--- a/ops/checklist_demo.md
+++ b/ops/checklist_demo.md
@@ -1,0 +1,8 @@
+# Demo QA Checklist
+
+- [ ] Run Demo -> rows appear.
+- [ ] Export Excel -> file has correct columns.
+- [ ] Upload (Demo) -> shows success UI state.
+- [ ] Approval required for WhatsApp.
+- [ ] Message preview personalized and correct.
+- [ ] No network calls or real secrets used.

--- a/prompts/seo_audit_prompt.txt
+++ b/prompts/seo_audit_prompt.txt
@@ -1,0 +1,6 @@
+Analyze the restaurant website at {{url}} and return a JSON object:
+{
+  "issues": ["concise issue", ...],
+  "fixes": ["matching fix", ...]
+}
+Only return valid JSON.

--- a/schemas/seo_audit.schema.json
+++ b/schemas/seo_audit.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "issues": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "fixes": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["issues", "fixes"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- set up demo SPA to search Strumica restaurants, scrape mock sites, audit SEO, export Excel, and simulate Drive & WhatsApp
- provide adapters for SerpApi, OpenAI, Drive, and WhatsApp with demo stubs and live hooks
- include n8n workflows, prompts, schema, and docs for fully offline demo

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896741cf890833098c4566127017769